### PR TITLE
Allow users to share usernames discreetly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ modhelp - Show commands available to moderators
 adminhelp - Show commands available to admins
 toggledebug - Toggle debug mode (sends back all messages to you)
 togglekarma - Toggle karma notifications
+togglerequests - Toggle DM request notifications
 tripcode - Show or set the tripcode for your messages
 ```
 

--- a/src/core.py
+++ b/src/core.py
@@ -313,6 +313,13 @@ def toggle_karma(user):
 	return rp.Reply(rp.types.BOOLEAN_CONFIG, description="Karma notifications", enabled=not new)
 
 @requireUser
+def toggle_requests(user):
+	with db.modifyUser(id=user.id) as user:
+		user.hideRequests = not user.hideRequests
+		new = user.hideRequests
+	return rp.Reply(rp.types.BOOLEAN_CONFIG, description="DM request notifications", enabled=not new)
+
+@requireUser
 def get_tripcode(user):
 	if not enable_signing:
 		return rp.Reply(rp.types.ERR_COMMAND_DISABLED)
@@ -487,6 +494,17 @@ def give_karma(user, msid):
 		_push_system_message(rp.Reply(rp.types.KARMA_NOTIFICATION), who=user2, reply_to=msid)
 	return rp.Reply(rp.types.KARMA_THANK_YOU)
 
+@requireUser
+def request_dm(user, msid):
+	cm = ch.getMessage(msid)
+	if cm is None or cm.user_id is None:
+		return rp.Reply(rp.types.ERR_NOT_IN_CACHE)
+	if user.id == cm.user_id:
+		return rp.Reply(rp.types.ERR_DM_REQUEST_OWN_MESSAGE)
+	user2 = db.getUser(id=cm.user_id)
+	if not user2.hideRequests:
+		_push_system_message(rp.Reply(rp.types.DM_REQUEST_NOTIFICATION), who=user2, reply_to=msid, sender=user)
+	return rp.Reply(rp.types.DM_REQUEST_ACKNOWLEDGEMENT)
 
 @requireUser
 def prepare_user_message(user: User, msg_score, *, is_media=False, signed=False, tripcode=False):

--- a/src/core.py
+++ b/src/core.py
@@ -503,7 +503,7 @@ def request_dm(user, msid):
 		return rp.Reply(rp.types.ERR_DM_REQUEST_OWN_MESSAGE)
 	user2 = db.getUser(id=cm.user_id)
 	if not user2.hideRequests:
-		_push_system_message(rp.Reply(rp.types.DM_REQUEST_NOTIFICATION), who=user2, reply_to=msid, sender=user)
+		_push_system_message(rp.Reply(rp.types.DM_REQUEST_NOTIFICATION, username=user.getFormattedName()), who=user2, reply_to=msid)
 	return rp.Reply(rp.types.DM_REQUEST_ACKNOWLEDGEMENT)
 
 @requireUser

--- a/src/database.py
+++ b/src/database.py
@@ -19,7 +19,7 @@ class SystemConfig():
 USER_PROPS = (
 	"id", "username", "realname", "rank", "joined", "left", "lastActive",
 	"cooldownUntil", "blacklistReason", "warnings", "warnExpiry", "karma",
-	"hideKarma", "debugEnabled", "tripcode"
+	"hideKarma", "hideRequests", "debugEnabled", "tripcode"
 )
 
 class User():
@@ -38,6 +38,7 @@ class User():
 		self.warnExpiry = None # datetime?
 		self.karma = None # int
 		self.hideKarma = None # bool
+		self.hideRequests = None # bool
 		self.debugEnabled = None # bool
 		self.tripcode = None # str?
 	def __eq__(self, other):
@@ -53,6 +54,7 @@ class User():
 		self.warnings = 0
 		self.karma = 0
 		self.hideKarma = False
+		self.hideRequests = False
 		self.debugEnabled = False
 	def isJoined(self):
 		return self.left is None
@@ -185,7 +187,7 @@ class JSONDatabase(Database):
 	def _userToDict(user):
 		props = ["id", "username", "realname", "rank", "joined", "left",
 			"lastActive", "cooldownUntil", "blacklistReason", "warnings",
-			"warnExpiry", "karma", "hideKarma", "debugEnabled", "tripcode"]
+			"warnExpiry", "karma", "hideKarma", "hideRequests", "debugEnabled", "tripcode"]
 		d = {}
 		for prop in props:
 			value = getattr(user, prop)
@@ -197,7 +199,7 @@ class JSONDatabase(Database):
 	def _userFromDict(d):
 		if d is None: return None
 		props = ["id", "username", "realname", "rank", "blacklistReason",
-			"warnings", "karma", "hideKarma", "debugEnabled"]
+			"warnings", "karma", "hideKarma", "hideRequests", "debugEnabled"]
 		props_d = [("tripcode", None)]
 		dateprops = ["joined", "left", "lastActive", "cooldownUntil", "warnExpiry"]
 		user = User()
@@ -317,6 +319,7 @@ CREATE TABLE IF NOT EXISTS `users` (
 	`warnExpiry` TIMESTAMP,
 	`karma` INTEGER NOT NULL,
 	`hideKarma` TINYINT NOT NULL,
+	`hideRequests` TINYINT NOT NULL,
 	`debugEnabled` TINYINT NOT NULL,
 	`tripcode` TEXT,
 	PRIMARY KEY (`id`)

--- a/src/replies.py
+++ b/src/replies.py
@@ -111,7 +111,7 @@ format_strs = {
 	types.KARMA_NOTIFICATION:
 		em( "You've just been given sweet karma! (check /info to see your karma"+
 			" or /toggleKarma to turn these notifications off)" ),
-	types.DM_REQUEST_NOTIFICATION: lambda sender, **_: em( "{sender} has requested contact in response to this message." + 
+	types.DM_REQUEST_NOTIFICATION: lambda username, **_: em( "{username!x} has requested contact in response to this message." + 
 			"\nRun /toggleRequests to turn these notifications off." ),
 	types.DM_REQUEST_ACKNOWLEDGEMENT: em("Your telegram username has been forwarded to this message's author."),
 	types.TRIPCODE_INFO: lambda tripcode, **_:

--- a/src/replies.py
+++ b/src/replies.py
@@ -41,6 +41,8 @@ types = NumericEnum([
 	"PROMOTED_ADMIN",
 	"KARMA_THANK_YOU",
 	"KARMA_NOTIFICATION",
+	"DM_REQUEST_NOTIFICATION",
+	"DM_REQUEST_ACKNOWLEDGEMENT",
 	"TRIPCODE_INFO",
 	"TRIPCODE_SET",
 
@@ -55,6 +57,7 @@ types = NumericEnum([
 	"ERR_BLACKLISTED",
 	"ERR_ALREADY_UPVOTED",
 	"ERR_UPVOTE_OWN_MESSAGE",
+	"ERR_DM_REQUEST_OWN_MESSAGE",
 	"ERR_SPAMMY",
 	"ERR_SPAMMY_SIGN",
 	"ERR_SIGN_PRIVACY",
@@ -108,6 +111,9 @@ format_strs = {
 	types.KARMA_NOTIFICATION:
 		em( "You've just been given sweet karma! (check /info to see your karma"+
 			" or /toggleKarma to turn these notifications off)" ),
+	types.DM_REQUEST_NOTIFICATION: lambda sender, **_: em( "{sender} has requested contact in response to this message." + 
+			"\nRun /toggleRequests to turn these notifications off." ),
+	types.DM_REQUEST_ACKNOWLEDGEMENT: em("Your telegram username has been forwarded to this message's author."),
 	types.TRIPCODE_INFO: lambda tripcode, **_:
 		"<b>tripcode</b>: " + ("<code>{tripcode!x}</code>" if tripcode is not None else "unset"),
 	types.TRIPCODE_SET: em("Tripcode set. It will appear as: ") + "<b>{tripname!x}</b> <code>{tripcode!x}</code>",
@@ -125,6 +131,7 @@ format_strs = {
 		( em("\ncontact:") + " {contact}" if contact else "" ),
 	types.ERR_ALREADY_UPVOTED: em("You have already upvoted this message."),
 	types.ERR_UPVOTE_OWN_MESSAGE: em("You can't upvote your own message."),
+	types.ERR_DM_REQUEST_OWN_MESSAGE: em("You can't request to DM yourself."),
 	types.ERR_SPAMMY: em("Your message has not been sent. Avoid sending messages too fast, try again later."),
 	types.ERR_SPAMMY_SIGN: em("Your message has not been sent. Avoid using /sign too often, try again later."),
 	types.ERR_SIGN_PRIVACY: em("Your account privacy settings prevent usage of the sign feature. Enable linked forwards first."),

--- a/src/telegram.py
+++ b/src/telegram.py
@@ -578,6 +578,7 @@ def cmd_motd(ev, arg):
 
 cmd_toggledebug = wrap_core(core.toggle_debug)
 cmd_togglekarma = wrap_core(core.toggle_karma)
+cmd_togglerequests = wrap_core(core.toggle_requests)
 
 @takesArgument(optional=True)
 def cmd_tripcode(ev, arg):
@@ -679,6 +680,15 @@ def plusone(ev):
 		return send_answer(ev, rp.Reply(rp.types.ERR_NOT_IN_CACHE), True)
 	return send_answer(ev, core.give_karma(c_user, reply_msid), True)
 
+def plusdm(ev):
+	c_user = UserContainer(ev.from_user)
+	if ev.reply_to_message is None:
+		return send_answer(ev, rp.Reply(rp.types.ERR_NO_REPLY), True)
+
+	reply_msid = ch.lookupMapping(ev.from_user.id, data=ev.reply_to_message.message_id)
+	if reply_msid is None:
+		return send_answer(ev, rp.Reply(rp.types.ERR_NOT_IN_CACHE), True)
+	return send_answer(ev, core.request_dm(c_user, reply_msid), True)
 
 def relay(ev):
 	# handle commands and karma giving
@@ -690,6 +700,8 @@ def relay(ev):
 			return
 		elif ev.text.strip() == "+1":
 			return plusone(ev)
+		elif ev.text.strip() == "+dm":
+			return plusdm(ev)
 	# manually handle signing / tripcodes for media since captions don't count for commands
 	if not is_forward(ev) and ev.content_type in CAPTIONABLE_TYPES and (ev.caption or "").startswith("/"):
 		c, arg = split_command(ev.caption)

--- a/src/telegram.py
+++ b/src/telegram.py
@@ -64,10 +64,10 @@ def init(config, _db, _ch):
 	types += ["animation", "audio", "photo", "sticker", "video", "video_note", "voice"]
 
 	cmds = [
-		"start", "stop", "users", "info", "motd", "toggledebug", "togglekarma",
-		"version", "source", "modhelp", "adminhelp", "modsay", "adminsay", "mod",
-		"admin", "warn", "delete", "remove", "uncooldown", "blacklist", "s", "sign",
-		"tripcode", "t", "tsign", "cleanup"
+		"start", "stop", "users", "info", "motd", "toggledebug", "togglekarma", 
+		"togglerequests", "version", "source", "modhelp", "adminhelp", "modsay", 
+		"adminsay", "mod", "admin", "warn", "delete", "remove", "uncooldown", 
+		"blacklist", "s", "sign", "tripcode", "t", "tsign", "cleanup"
 	]
 	for c in cmds: # maps /<c> to the function cmd_<c>
 		c = c.lower()

--- a/util/blacklist.py
+++ b/util/blacklist.py
@@ -101,6 +101,7 @@ def ban_user(db, id, reason):
 			"warnings": 0,
 			"karma": 0,
 			"hideKarma": 0,
+			"hideRequests": 0,
 			"debugEnabled": 0,
 		}
 		sql = "INSERT INTO users (" + ( ", ".join(u.keys()) ) + ") VALUES (" + ( ", ".join("?" for _ in u) ) + ")"

--- a/util/import.py
+++ b/util/import.py
@@ -61,6 +61,7 @@ def main(configpath, importpath):
 			u.warnExpiry = safe_time(j["warnUpdated"] // 1000) + timedelta(hours=WARN_EXPIRE_HOURS)
 		u.karma = j.get("karma", 0)
 		u.hideKarma = j.get("hideKarma", False)
+		u.hideRequests = j.get("hideRequests", False)
 		u.debugEnabled = j.get("debug", False)
 
 		if u.id in had_ids:


### PR DESCRIPTION
`+dm` command can be used to send @username to other users without sharing with the entire channel.